### PR TITLE
chore(example): load and run 

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -540,7 +540,8 @@ function clearAll() {
 function loadExample() {
     const exampleDirectives = `# Example WAF Configuration
 
-SecRuleEngine On # change this to DetectionOnly if you want to see all rules matched
+# Change SecRuleEngine to DetectionOnly if you want to see all rules matched
+SecRuleEngine On
 SecRequestBodyAccess On
 SecResponseBodyAccess On
 


### PR DESCRIPTION
Moves a comment on an empty line to allow users to just press `Load Example` followed by `Run Analysis` and see a successful outcome. 
Right now it leads to the following error:
```
Analysis failed: invalid WAF config from string: failed to compile the directive "secruleengine": invalid rule engine status: "On # change this to DetectionOnly if you want to see all rules matched"
```
I quickly checked Coraza and Modsec, and it looks like they are not accepting inline comments 