### PR TITLE
ci: fix `test` and `publish`

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,6 @@
 github.com/corazawaf/coraza-coreruleset v0.0.0-20240226094324-415b1017abdc h1:OlJhrgI3I+FLUCTI3JJW8MoqyM78WbqJjecqMnqG+wc=
 github.com/corazawaf/coraza-coreruleset v0.0.0-20240226094324-415b1017abdc/go.mod h1:7rsocqNDkTCira5T0M7buoKR2ehh7YZiPkzxRuAgvVU=
-github.com/corazawaf/coraza-coreruleset/v4 v4.15.0 h1:rfdp5NK7ehB8+f0wcCaEAmPJ3h/7pD7KT085xyNVKIo=
-github.com/corazawaf/coraza-coreruleset/v4 v4.15.0/go.mod h1:yeZPZUM23HVL0jMAzLfKF3M7XjCQBXDrvcQT/gkjwhg=
+github.com/corazawaf/coraza-coreruleset/v4 v4.16.0 h1:xbC785u2JYTkoZpYDchW3NOys8sKdFBmh2JTpva1Czc=
 github.com/corazawaf/coraza-coreruleset/v4 v4.16.0/go.mod h1:yeZPZUM23HVL0jMAzLfKF3M7XjCQBXDrvcQT/gkjwhg=
 github.com/corazawaf/coraza/v3 v3.3.3 h1:kqjStHAgWqwP5dh7n0vhTOF0a3t+VikNS/EaMiG0Fhk=
 github.com/corazawaf/coraza/v3 v3.3.3/go.mod h1:xSaXWOhFMSbrV8qOOfBKAyw3aOqfwaSaOy5BgSF8XlA=


### PR DESCRIPTION
https://github.com/corazawaf/coraza-playground/pull/60 has been automatically merged even if the CI was failing. Because of that, `Publish` and `Test` workflows are now failing in main branch. This PR should fix it. 
Build Failing error:
```
Error: cmd/playground/main.go:15:2: missing go.sum entry for module providing package github.com/corazawaf/coraza-coreruleset/v4; to add:
	go mod download github.com/corazawaf/coraza-coreruleset/v4
```